### PR TITLE
Donal's updates to NEON AOP chapter 07

### DIFF
--- a/07-NEON_AOP.Rmd
+++ b/07-NEON_AOP.Rmd
@@ -519,18 +519,15 @@ image. However, look at the images below. The top one is what our log adjusted
 image looks like when plotted. The bottom on is an RGB version of the same image. 
 Notice a difference? 
 
-![](https://raw.githubusercontent.com/NEONScience/NEON-Data-Skills/dev-aten/graphics/hyperspectral-general/RGBImage_2.png)
 
-">
-    <img src="https://raw.githubusercontent.com/NEONScience/NEON-Data-Skills/dev-aten/graphics/hyperspectral-general/RGBImage_2.png"
+<img src="https://raw.githubusercontent.com/NEONScience/NEON-Data-Skills/dev-aten/graphics/hyperspectral-general/RGBImage_2.png"
     alt="RGB image of the SJER field site. At the top right of the image, there is dark, brakish water. Scattered throughout the image, there are several trees. At the center of the image, there is a baseball field, with low grass. At the bottom left of the image, there is a parking lot and some buildings with highly reflective surfaces, and adjacent to it is a section of a gravel lot.">
     </a>
     <a href="https://raw.githubusercontent.com/NEONScience/NEON-Data-Skills/dev-aten/graphics/hyperspectral-general/SJER_Flipped.png">
     <img src="https://raw.githubusercontent.com/NEONScience/NEON-Data-Skills/dev-aten/graphics/hyperspectral-general/SJER_Flipped.png"
     alt="Plot of log transformed reflectance values for the b9 image previously plotted. Applying the log to the image increases the contrast making it look more like an image by factoring out those larger values. While an improvement, the image is still far from great. The proper way to adjust an image is by doing whats called an image stretch. The log transformed image appears flipped because when R reads in the dataset, it reads them as: Columns x Bands x Rows, as opposed to the RGB image on the left which has dimensions as Bands x Rows x Columns.">
     </a>
-    <figcaption>LEFT: The image as it should look. RIGHT: the image that we outputted from the code above. Notice a difference?</figcaption>
-</figure>
+    <figcaption>TOP: The image as it should look. BOTTOM: the image that we outputted from the code above. Notice a difference?</figcaption>
 
 
 ### Transpose Image
@@ -1263,12 +1260,15 @@ Prior to starting the tutorial ensure that the following packages are installed.
 
 ### Example Data Set
 
-############# Possibly add GEDI subset here?? ##############
+#### GEDI Example Data Subset
+This dataset has been subset from a full GEDI orbit retaining only the 'shots' that correspond to a single 1km AOP tile, and only the 'datasets' (attributes) that are needed to visualize the GEDI waveform as shown below.
+<a href="https://ndownloader.figshare.com/files/24978809" class="link--button link--arrow">
+Download GEDI Example Dataset</a>
 
 #### Datum difference between WGS84 and NAD83
 This dataset describes the differences between two common standards for vertical data in North America.
 <a href="https://neondata.sharefile.com/d-sf4e35e969fc43aca" class="link--button link--arrow">
-Download Dataset</a>
+Download Datum Difference Dataset</a>
 
 
 ### Getting Started
@@ -1309,7 +1309,7 @@ byTileAOP(dpID = "DP3.30015.001", site = SITECODE, year = 2017,
           easting = 580000, northing = 5075000, check.size = F,
           savepath = './data')
 
-chm <- raster('./data/DP3.30015.001/2017/FullSite/D16/2017_WREF_1/L3/DiscreteLidar/CanopyHeightModelGtif/NEON_D16_WREF_DP3_580000_5075000_CHM.tif')
+chm <- raster('~/Downloads/DP3.30015.001/2017/FullSite/D16/2017_WREF_1/L3/DiscreteLidar/CanopyHeightModelGtif/NEON_D16_WREF_DP3_580000_5075000_CHM.tif')
 
 plot(chm)
 
@@ -1318,11 +1318,12 @@ plot(chm)
 As you can see, this particular CHM is showing a conspicuous, triangle-shaped clearcut in this section of the experimental forest, where the tree canopy is much shorter than the towering 60m+ trees in the undisturbed areas. This variation will give us a variety of forest structures to investigate.
 
 ### Downloading GEDI data
-This next section on downloading and working with GEDI data is loosely based on the excellent `rGEDI` package tutorial <a href="https://cran.r-project.org/web/packages/rGEDI/vignettes/tutorial.html">posted on CRAN here</a>.
+This next section on downloading and working with GEDI data is loosely based on the excellent `rGEDI` package tutorial <a href="https://cran.r-project.org/web/packages/rGEDI/vignettes/tutorial.html">posted on CRAN here</a>. If you would prefer to avoid a large download (>7Gb) of a full GEDI orbit, you can forego these steps and use the <a href="https://ndownloader.figshare.com/files/24978809">
+example GEDI dataset here</a>, and skip to the `readLevel1B()` function below.
 
 The Global Ecosystem Dynamics Investigation (GEDI) is a NASA mission with the primary data collection being performed by a novel waveform lidar instrument mounted on the International Space Station (ISS). Please see <a href="https://www.sciencedirect.com/science/article/pii/S2666017220300018">this open-access paper</a> published in Science of Remote Sensing that describes this mission in detail. The ISS orbits around the world every 90 minutes, and can be tracked <a href="https://spotthestation.nasa.gov/tracking_map.cfm">on this cool NASA website</a>. 
 
-As described <a href="https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/gedi-overview/">here</a> on the Land Processes Distributed Active Archive Center (LP DAAC), "the sole GEDI observable is the waveform from which all other data products are derived. Each waveform is captured with a nominal ~30 m diameter."GEDI has six   As of the date of publication, GEDI data are only offered in HDF5 format, with each file containing the data for a full orbit. The LP DAAC has developed a tool that allows researchers to input a bounding box, which will return a list of every orbit that has a "shot" (waveform return) that falls within that box. Unfortunately, at this time, the tool will not subset out the specific shots that fall within that bounding box; you must download the entire orbit (~7Gb). This functionality may be improved in the future.
+As described <a href="https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/gedi-overview/">here</a> on the Land Processes Distributed Active Archive Center (LP DAAC), "the sole GEDI observable is the waveform from which all other data products are derived. Each waveform is captured with a nominal ~30 m diameter." As of the date of publication, GEDI data are only offered in HDF5 format, with each file containing the data for a full orbit. The LP DAAC has developed a tool that allows researchers to input a bounding box, which will return a list of every orbit that has a "shot" (waveform return) that falls within that box. Unfortunately, at this time, the tool will not subset out the specific shots that fall within that bounding box; you must download the entire orbit (~7Gb). This functionality may be improved in the future.
 
 Our next few steps involve defining our bounding box, requesting the list of GEDI orbits that contain data relevant to that bounding box, and downloading those data. Let's focus on the extent of our CHM that we downloaded above - but we will first need to re-project the CHM from its UTM projection into WGS84. To do so, we will refer to the EPSG code for WGS84. To look up any of these codes, please see the amazing resource <a href="https://spatialreference.org/ref/epsg/4326/">spatialrerference.org</a>.
 
@@ -1366,6 +1367,9 @@ Great! There are several GEDI orbits available that have at least 1 'shot' withi
 ```{r download-GEDI, eval=F, comment=NA}
 
 # Downloading GEDI data, if you haven't already
+# Note that this will download a large file (>7Gb) which
+# can be avoided by using the example dataset provided above.
+
 # if(!file.exists(paste0(wd,basename(gLevel1B[2])))){
 #   gediDownload(filepath=gLevel1B[2],outdir=wd)
 # }
@@ -1376,7 +1380,7 @@ Next, we use the rGEDI package to read in the GEDI data. First, we need to make 
 
 ```{r read-GEDI, message=F}
 
-gedilevel1b<-readLevel1B(level1Bpath = file.path('./data/NEON_GEDI_subset.h5'))
+gedilevel1b<-readLevel1B(level1Bpath = file.path('./data/NEON_WREF_GEDI_subset.h5'))
 #gedilevel1b<-readLevel1B(level1Bpath = file.path(wd, "GEDI01_B_2019206022612_O03482_T00370_02_003_01.h5"))
 level1bGeo<-getLevel1BGeo(level1b=gedilevel1b,select=c("elevation_bin0"))
 head(level1bGeo)
@@ -1427,13 +1431,14 @@ pointLabel(st_coordinates(level1bgeo_WREF_UTM),
 ```
 
 ### Extract Waveform for a single Shot
-Let's take a look at a waveform for a single GEDI shot. We will use the last three numbers of the shot, shown a labels in the plot above, to select a waveform of interest. In this case, let's plot the the footprint labeled '002' in the northwest of the CHM.
+Let's take a look at a waveform for a single GEDI shot. We can select a shot by using its `shot_number` as shown below. Note, however, that the example data subset shots have been re-numbered, and those numbers will not correspond with full orbit GEDI data.
 
 ```{r extract-wf, warning=F}
 
 # Extracting GEDI full-waveform for a given shot_number
-###ERROR HERE###
 wf <- getLevel1BWF(gedilevel1b,shot_number = 20)
+
+# or, if using a full GEDI dataset,
 # wf <- getLevel1BWF(gedilevel1b,shot_number = level1bgeo_WREF_UTM_buffer$shot_number[which(level1bgeo_WREF_UTM_buffer$shot_number==1786)])
 
 # Save current plotting parameters to revert to
@@ -1468,7 +1473,7 @@ Here, we will use the `byTileAOP()` function from the 'neonUtilities' package to
 if (!file.exists('./data/DP1.30003.001/2017/FullSite/D16/2017_WREF_1/L1/DiscreteLidar/ClassifiedPointCloud/NEON_D16_WREF_DP1_580000_5075000_classified_point_cloud.laz')){
   byTileAOP(dpID = "DP1.30003.001", site = SITECODE, year = 2017, 
           easting = extent(chm)[1], northing=extent(chm)[3], 
-          check.size = F)
+          check.size = F, savepath = './data/') # Edit savepath as needed
 }
 
 ```
@@ -1524,7 +1529,7 @@ Now that we can extract individual waveforms, and the AOP LiDAR pointcloud that 
 
 ```{r plot-lidar-together-1, eval=FALSE}
 
-for(shot_n in 1:21){
+for(shot_n in c(20)){
 
   # First, plot the NEON AOP LiDAR clipped to the GEDI footprint
   # We save the plot as an object 'p' which gives the (x,y) offset for the lower
@@ -1559,7 +1564,7 @@ for(shot_n in 1:21){
 
 ```
 
-Whoa, it looks like there is a bad vertical mismatch between those two data sources. This is because the two data sources have a different vertical datum. The NEON AOP data are delivered in the GEOID12A, while the GEDI data are delivered in the WGS84 native datum. We will need to convert one to the other to get them to line up correctly.
+Whoa, it looks like there is a bad vertical mismatch between those two data sources. This is because the two data sources have a different vertical datum. The NEON AOP data are delivered in the GEOID12A datum, while the GEDI data are delivered in the WGS84 native datum. We will need to convert one to the other to get them to line up correctly.
 
 ### Datum, Geoid, and how to best measure the Earth
 We are seeing a vertical mismatch between the NEON and GEDI LiDAR data sources because they are using different standards for measuring the Earth. Here, we will briefly describe the main differences between these two datum models, and then show how to correct for this discrepancy.
@@ -1734,7 +1739,7 @@ You may also be interested to see if any of the GEDI footprints intersect a NEON
 
 ```{r import and plot base plots}
 
-setwd("./data/")
+setwd("./data/") # This will depend upon your local environment
 
 # Download the NEON TOS plots polygons directly from the NEON website
 download.file(url="https://data.neonscience.org/api/v0/documents/All_NEON_TOS_Plots_V8", 


### PR DESCRIPTION
Hi @katharynduffy , I made some edits to this Rmarkdown file, including adding a link to the NEON-GEDI data subset, removed some of my 'notes to self', and explained a bit more that the functions for searching for GEDI data are unnecessary if using the example data subset.

While it's on my mind, I think that an interesting follow-up/homework question for your students would be: why do some of the waveforms seems to correspond with the NEON pointclouds better than others? What I'm getting at is (x,y) location uncertainty for the GEDI footprints can cause alignment problems between GEDI and ALS data. For example, if GEDI reports the footprint to be within a clearcut area, but the actual GEDI waveform was a few meters to the side, the returned waveform might have some taller trees in the return signal that are not within the precisely defined footprint (e.g., the opposite of this in shot #17 in example dataset). Perhaps students could experiment with the location uncertainty (though this is not within the example dataset, students would need to retrieve full GEDI data to access that attribute). 